### PR TITLE
feat: implement component registry system (Header/Footer mapping)

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,0 +1,409 @@
+# Pencil Code Generator
+
+Convert `.pen` design files to React + Tailwind CSS components automatically.
+
+## Features
+
+- ✅ Frame → React Component conversion
+- ✅ Style → Tailwind class conversion
+- ✅ Flexbox and Grid layout generation
+- ✅ Responsive breakpoint generation
+- ✅ Theme variable extraction
+- ✅ **Template System** - Reusable page layouts and components
+- ✅ **Frame References** - Reference and reuse frames across templates
+- ✅ **Component References** - Import and compose components
+- ✅ **Nested Templates** - Templates within templates
+- ✅ **Component Registry** - Map .pen components to React components with parameter extraction
+
+## Usage
+
+### CLI
+
+```bash
+# Generate a single component
+node codegen/cli.js Homepage.pen
+
+# Generate with custom output directory
+node codegen/cli.js Homepage.pen --output ./src/pages --name HomePage
+
+# Generate all frames as separate components
+node codegen/cli.js Homepage.pen --all
+```
+
+### Programmatic
+
+```javascript
+import { generate, generateAll } from './codegen/generator/index.js';
+
+// Read .pen file
+const penData = JSON.parse(fs.readFileSync('Homepage.pen', 'utf8'));
+
+// Generate single component
+const result = generate(penData, {
+  outputDir: './src/components',
+  componentName: 'HomePage',
+});
+
+console.log(result.componentCode);
+
+// Generate all frames
+const components = generateAll(penData);
+components.forEach(comp => {
+  console.log(`${comp.name} → ${comp.componentName}`);
+});
+```
+
+### Template System
+
+```javascript
+import { renderTemplate, renderPage } from './codegen/template-engine/index.js';
+
+// Render a frame template
+const frame = renderTemplate('frame-template', {
+  name: 'HeroSection',
+  width: 'fill_container',
+  height: 600,
+  layout: 'vertical',
+});
+
+// Render a page with Header + Main + Footer
+const page = renderPage({
+  main: {
+    type: 'frame',
+    name: 'MainContent',
+    children: [/* ... */],
+  },
+  // header and footer use defaults (components/header, components/footer)
+});
+
+// Use custom header
+const customPage = renderPage({
+  main: mainContent,
+  header: { type: 'frame', name: 'CustomHeader', /* ... */ },
+  footer: { type: 'frame', name: 'CustomFooter', /* ... */ },
+});
+
+// Use component references
+const withRefs = renderTemplate('frame-template', {
+  name: 'PageWithRefs',
+  children: [
+    {
+      type: 'reference',
+      ref: 'components/header',
+      props: { logoText: 'MyBrand' },
+    },
+  ],
+});
+```
+
+### Component Registry
+
+```javascript
+import { registry, createRegistry } from './codegen/components/registry.js';
+
+// Resolve component paths
+const headerPath = registry.resolve('Header');
+console.log(headerPath); // '../components/Header'
+
+// Generate imports
+const importStmt = registry.generateImport('Header');
+console.log(importStmt); // "import { Header } from './components/Header';"
+
+// Generate JSX
+const jsx = registry.generateJSX('Header', { logoText: 'MyBrand' });
+console.log(jsx); // '<Header logoText="MyBrand" />'
+
+// Extract parameters from .pen frame data
+const params = registry.extractParams({
+  type: 'frame',
+  name: 'Hero',
+  width: 1440,
+  children: [{ type: 'text', content: 'Welcome', fontSize: 48 }]
+});
+
+// Register custom components
+registry.register('CustomButton', '../components/CustomButton');
+registry.saveConfig();
+
+// Generate complete component with references
+const code = registry.generateComponentWithRefs('HomePage', [
+  { penName: 'Header', props: { logoText: 'Brand' } },
+  { penName: 'Footer' }
+]);
+```
+
+See [Component Registry Usage Guide](components/README.md) for full documentation.
+
+## Project Structure
+
+```
+codegen/
+├── cli.js                          # Command-line interface
+├── generator/
+│   ├── index.js                    # Main generator entry
+│   ├── component-generator.js      # React component generation
+│   ├── style-generator.js          # Tailwind style generation
+│   ├── layout-generator.js         # Flexbox/Grid layout generation
+│   └── responsive-generator.js     # Responsive breakpoint generation
+├── template-engine/
+│   ├── index.js                    # Template rendering engine
+│   └── template-engine.test.js     # Template engine tests
+├── templates/
+│   ├── page-template.json          # Page layout (Header+Main+Footer)
+│   ├── frame-template.json         # Reusable frame template
+│   ├── reference-template.json     # Component reference template
+│   └── components/
+│       ├── header.json             # Header component template
+│       └── footer.json             # Footer component template
+├── components/
+│   ├── registry.js                 # Component registry (maps .pen to React)
+│   ├── registry.test.js            # Registry test suite
+│   ├── components.config.json      # Component mapping configuration
+│   └── README.md                   # Component registry usage guide
+├── examples/
+│   └── template-usage.js           # Template usage examples
+├── generator.test.js               # Generator test suite
+└── README.md                       # This file
+```
+
+## Template System
+
+### Template Format
+
+Templates are JSON files with the following structure:
+
+```json
+{
+  "name": "TemplateName",
+  "description": "What this template does",
+  "version": "1.0.0",
+  "parameters": {
+    "paramName": {
+      "type": "string|number|object|array",
+      "description": "Parameter description",
+      "default": "defaultValue"
+    }
+  },
+  "structure": {
+    "type": "frame",
+    "name": "${paramName}",
+    "children": []
+  }
+}
+```
+
+### Parameter Substitution
+
+Use `${paramName}` in template structures to substitute values:
+
+```json
+{
+  "type": "frame",
+  "name": "${name}",
+  "width": "${width}",
+  "height": "${height}"
+}
+```
+
+### Component References
+
+Reference other templates/components using the `reference` type:
+
+```json
+{
+  "type": "reference",
+  "ref": "components/header",
+  "props": {
+    "logoText": "MyBrand",
+    "navItems": ["Home", "About"]
+  }
+}
+```
+
+### Page Template
+
+The page template provides a standard layout with three slots:
+
+- **header** (optional) - Defaults to `components/header`
+- **main** (required) - Page-specific content
+- **footer** (optional) - Defaults to `components/footer`
+
+```javascript
+import { renderPage } from './codegen/template-engine/index.js';
+
+const page = renderPage({
+  main: {
+    type: 'frame',
+    name: 'HomePage',
+    children: [/* page content */],
+  },
+});
+```
+
+## Generator Modules
+
+### Component Generator (`component-generator.js`)
+
+Converts Frame data to React components:
+
+- `generateComponent(frameData, componentName)` - Main generation function
+- `generateContainerClasses(frame)` - Generate container div classes
+- `generateTextClasses(text)` - Generate text element classes
+
+### Style Generator (`style-generator.js`)
+
+Extracts and converts design styles:
+
+- `generateStyles(penData)` - Extract all styles
+- `generateCSSVariables(variables)` - Generate CSS custom properties
+- `generateTailwindConfig(colors)` - Generate Tailwind config extension
+
+### Layout Generator (`layout-generator.js`)
+
+Generates layout structures:
+
+- `generateLayout(frameData)` - Main layout generation
+- `generateFlexLayout(frame)` - Flexbox classes
+- `generateGridLayout(frame, columns)` - Grid classes
+
+### Responsive Generator (`responsive-generator.js`)
+
+Generates responsive breakpoints:
+
+- `generateResponsive(frameData)` - All breakpoint classes
+- `generateResponsiveFontSize(fontSize)` - Responsive typography
+- `generateResponsiveWidth(width)` - Responsive widths
+
+### Template Engine (`template-engine/index.js`)
+
+Renders templates with parameter substitution and reference resolution:
+
+- `loadTemplate(templateName)` - Load a template from disk
+- `renderTemplate(templateName, params)` - Render a template with parameters
+- `renderPage(slots)` - Render a page with Header/Main/Footer slots
+- `resolveReferences(structure)` - Resolve component references
+- `substituteParams(structure, params)` - Substitute parameters in structure
+- `listTemplates()` - List all available templates
+
+### Component Registry (`components/registry.js`)
+
+Maps .pen component names to React component paths:
+
+- `createRegistry(options)` - Create a new registry instance
+- `registry.resolve(penName)` - Get React component path for a .pen name
+- `registry.register(penName, reactPath)` - Register a new component mapping
+- `registry.has(penName)` - Check if a component is registered
+- `registry.extractParams(frameData)` - Extract parameters from .pen frame data
+- `registry.generateImport(penName)` - Generate import statement
+- `registry.generateJSX(penName, props)` - Generate JSX reference
+- `registry.generateImports(penNames)` - Generate multiple imports
+- `registry.generateJSXMultiple(components)` - Generate JSX for multiple components
+- `registry.generateComponentWithRefs(name, children)` - Generate complete component
+- `registry.saveConfig()` - Save component mappings to config file
+
+## Examples
+
+See `codegen/examples/template-usage.js` for comprehensive usage examples.
+
+## Testing
+
+```bash
+# Run all tests
+npm test
+
+# Run generator tests only
+npm test -- codegen/generator.test.js
+
+# Run template engine tests only
+npm test -- codegen/template-engine/template-engine.test.js
+```
+
+## Acceptance Criteria
+
+### Template System (Issue #8)
+- ✅ Reusable Header/Footer components via templates
+- ✅ Page structure correctly generated with Header + Main + Footer
+- ✅ Component references properly parsed and resolved
+- ✅ Nested templates supported (templates within templates)
+- ✅ Parameter substitution working
+- ✅ Template caching for performance
+
+### Component Registry (Issue #9)
+- ✅ Header/Footer correctly mapped to React components
+- ✅ Component parameters properly extracted from .pen frame data
+- ✅ Import statements correctly generated
+- ✅ JSX references properly formatted with props
+- ✅ Custom component registration supported
+- ✅ Configuration file for persistent mappings
+- ✅ Complete component generation with references
+
+## Examples
+
+### Input (.pen file)
+
+```json
+{
+  "type": "frame",
+  "name": "Hero",
+  "width": 1440,
+  "layout": "vertical",
+  "padding": [40, 80],
+  "children": [
+    {
+      "type": "text",
+      "content": "Welcome",
+      "fontSize": 48,
+      "fontWeight": "bold"
+    }
+  ]
+}
+```
+
+### Output (React Component)
+
+```jsx
+import React from 'react';
+
+/**
+ * HeroComponent
+ * Auto-generated from Pencil design file
+ */
+export function HeroComponent() {
+  return (
+    <div className="flex flex-col py-10 px-20">
+      <span className="text-5xl font-bold">Welcome</span>
+    </div>
+  );
+}
+
+export default HeroComponent;
+```
+
+## Configuration
+
+The generator uses sensible defaults but can be configured:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `outputDir` | `./src/components` | Output directory for generated files |
+| `componentName` | Auto-generated | Name for the React component |
+| `all` | `false` | Generate all frames as separate components |
+
+## Limitations
+
+- Some complex `.pen` features may not have direct Tailwind equivalents
+- Custom fonts need to be configured separately
+- Image assets are referenced but not processed
+- Theme variables use CSS custom properties (requires Tailwind config)
+
+## Future Enhancements
+
+- [ ] Support for more `.pen` element types
+- [ ] Automatic prop extraction for dynamic content
+- [ ] Storybook story generation
+- [ ] TypeScript type generation
+- [ ] Component composition from references
+
+## License
+
+ISC

--- a/codegen/components/README.md
+++ b/codegen/components/README.md
@@ -1,0 +1,422 @@
+# Component Registry Usage Guide
+
+## Overview
+
+The Component Registry maps `.pen` design component names to React component paths, enabling automatic code generation with proper imports and JSX references.
+
+## Quick Start
+
+```javascript
+import { registry, createRegistry } from '../codegen/components/registry.js';
+
+// Use the default registry
+const reactPath = registry.resolve('Header');
+console.log(reactPath); // '../components/Header'
+
+// Or create a custom registry
+const customRegistry = createRegistry({
+  configPath: './my-components.config.json',
+});
+```
+
+## API Reference
+
+### ComponentRegistry Class
+
+#### Constructor
+
+```javascript
+const registry = new ComponentRegistry(options);
+```
+
+Options:
+- `configPath` - Path to component configuration file (default: `codegen/components/components.config.json`)
+- `outputDir` - Output directory for generated components (default: `src/components`)
+
+#### Methods
+
+##### `register(penName, reactPath)`
+
+Register a new component mapping.
+
+```javascript
+registry.register('CustomButton', '../components/CustomButton');
+```
+
+##### `unregister(penName)`
+
+Remove a component mapping.
+
+```javascript
+registry.unregister('Header');
+```
+
+##### `has(penName)`
+
+Check if a component is registered.
+
+```javascript
+if (registry.has('Header')) {
+  console.log('Header component available');
+}
+```
+
+##### `resolve(penName)`
+
+Get the React component path for a .pen component name.
+
+```javascript
+const path = registry.resolve('Footer');
+console.log(path); // '../components/Footer'
+```
+
+##### `getAll()`
+
+Get all registered component mappings.
+
+```javascript
+const mappings = registry.getAll();
+console.log(mappings);
+// { Header: '../components/Header', Footer: '../components/Footer', ... }
+```
+
+##### `extractParams(frameData)`
+
+Extract parameters from a .pen frame definition.
+
+```javascript
+const frameData = {
+  type: 'frame',
+  name: 'Hero',
+  width: 1440,
+  height: 600,
+  children: [
+    { type: 'text', content: 'Welcome', fontSize: 48 }
+  ]
+};
+
+const params = registry.extractParams(frameData);
+console.log(params);
+// { name: 'Hero', width: 1440, height: 600, children: [...] }
+```
+
+##### `generateImport(penName)`
+
+Generate an import statement for a component.
+
+```javascript
+const importStmt = registry.generateImport('Header');
+console.log(importStmt);
+// "import { Header } from './components/Header';"
+```
+
+##### `generateJSX(penName, props)`
+
+Generate JSX reference for a component.
+
+```javascript
+const jsx = registry.generateJSX('Header', { logoText: 'MyBrand' });
+console.log(jsx);
+// '<Header logoText="MyBrand" />'
+```
+
+##### `generateImports(penNames)`
+
+Generate import statements for multiple components.
+
+```javascript
+const imports = registry.generateImports(['Header', 'Footer', 'Hero']);
+console.log(imports);
+// import { Header } from './components/Header';
+// import { Footer } from './components/Footer';
+// import { Hero } from './components/Hero';
+```
+
+##### `generateJSXMultiple(components)`
+
+Generate JSX for multiple components.
+
+```javascript
+const jsx = registry.generateJSXMultiple([
+  { penName: 'Header', props: { logoText: 'Brand' } },
+  { penName: 'Footer' },
+  { penName: 'Hero', props: { title: 'Welcome' } }
+]);
+```
+
+##### `generateComponentWithRefs(componentName, children)`
+
+Generate a complete React component with imported references.
+
+```javascript
+const code = registry.generateComponentWithRefs('HomePage', [
+  { penName: 'Header', props: { logoText: 'MySite' } },
+  { penName: 'Hero', props: { title: 'Welcome' } },
+  { penName: 'Footer' }
+]);
+
+console.log(code);
+// import React from 'react';
+// import { Header } from './components/Header';
+// import { Hero } from './components/Hero';
+// import { Footer } from './components/Footer';
+//
+// export function HomePage() {
+//   return (
+//     <>
+//       <Header logoText="MySite" />
+//       <Hero title="Welcome" />
+//       <Footer />
+//     </>
+//   );
+// }
+```
+
+##### `getComponentName(penName)`
+
+Convert a .pen name to PascalCase component name.
+
+```javascript
+const name = registry.getComponentName('my-component');
+console.log(name); // 'MyComponent'
+```
+
+##### `getRelativePath(sourceFile, penName)`
+
+Get the relative import path from a source file to a component.
+
+```javascript
+const relPath = registry.getRelativePath('/src/pages/Home.jsx', 'Header');
+console.log(relPath); // '../components/Header'
+```
+
+##### `saveConfig()`
+
+Save current component mappings to the config file.
+
+```javascript
+registry.register('CustomButton', '../components/CustomButton');
+registry.saveConfig();
+```
+
+## Configuration File
+
+The component registry uses a JSON configuration file:
+
+```json
+{
+  "version": "1.0.0",
+  "description": "Component mappings for Pencil Code Generator",
+  "components": {
+    "Header": "../components/Header",
+    "Footer": "../components/Footer",
+    "Button": "../components/Button",
+    "CustomComponent": "../components/CustomComponent"
+  }
+}
+```
+
+### Location
+
+Default: `codegen/components/components.config.json`
+
+Custom:
+
+```javascript
+const registry = new ComponentRegistry({
+  configPath: './custom-components.config.json'
+});
+```
+
+## Integration with Code Generator
+
+The registry integrates with the code generator to automatically import and reference components:
+
+```javascript
+import { generate } from '../codegen/generator/index.js';
+import { registry } from '../codegen/components/registry.js';
+
+const penData = JSON.parse(fs.readFileSync('Homepage.pen', 'utf8'));
+
+// Extract component references from .pen data
+const componentRefs = extractComponentRefs(penData);
+
+// Generate imports
+const imports = registry.generateImports(componentRefs.map(r => r.penName));
+
+// Generate JSX
+const jsx = registry.generateJSXMultiple(componentRefs);
+
+// Combine with generated code
+const finalCode = `${imports}
+
+${generatedComponentCode}
+`;
+```
+
+## Examples
+
+### Example 1: Basic Usage
+
+```javascript
+import { registry } from '../codegen/components/registry.js';
+
+// Check if component exists
+if (registry.has('Header')) {
+  // Generate import and JSX
+  const importStmt = registry.generateImport('Header');
+  const jsx = registry.generateJSX('Header', { logoText: 'MyBrand' });
+  
+  console.log(importStmt); // import { Header } from './components/Header';
+  console.log(jsx);        // <Header logoText="MyBrand" />
+}
+```
+
+### Example 2: Custom Component Registration
+
+```javascript
+import { createRegistry } from '../codegen/components/registry.js';
+
+const registry = createRegistry();
+
+// Register custom components
+registry.register('MyButton', '../components/ui/MyButton');
+registry.register('MyCard', '../components/ui/MyCard');
+
+// Save configuration
+registry.saveConfig();
+
+// Use in code generation
+const code = registry.generateComponentWithRefs('CustomPage', [
+  { penName: 'MyButton', props: { label: 'Click Me' } },
+  { penName: 'MyCard', props: { title: 'Card Title' } }
+]);
+```
+
+### Example 3: Parameter Extraction
+
+```javascript
+import { registry } from '../codegen/components/registry.js';
+
+const frameData = {
+  type: 'frame',
+  name: 'Hero',
+  width: 1440,
+  height: 600,
+  padding: [40, 80],
+  layout: 'vertical',
+  children: [
+    {
+      type: 'text',
+      content: 'Welcome to Our Site',
+      fontSize: 48,
+      fontWeight: 'bold'
+    },
+    {
+      type: 'frame',
+      name: 'CTA Button',
+      children: [
+        {
+          type: 'text',
+          content: 'Get Started',
+          fontSize: 16
+        }
+      ]
+    }
+  ]
+};
+
+const params = registry.extractParams(frameData);
+console.log(params);
+// {
+//   name: 'Hero',
+//   width: 1440,
+//   height: 600,
+//   padding: [40, 80],
+//   layout: 'vertical',
+//   children: [
+//     { content: 'Welcome to Our Site', fontSize: 48, fontWeight: 'bold' },
+//     { name: 'CTA Button', children: [...] }
+//   ]
+// }
+```
+
+### Example 4: Integration with Template Engine
+
+```javascript
+import { renderPage } from '../codegen/template-engine/index.js';
+import { registry } from '../codegen/components/registry.js';
+
+// Render a page with component references
+const page = renderPage({
+  main: {
+    type: 'frame',
+    name: 'HomePage',
+    children: [
+      {
+        type: 'reference',
+        ref: 'Header',
+        props: { logoText: 'MyBrand' }
+      },
+      {
+        type: 'frame',
+        name: 'Content',
+        children: [/* page content */]
+      },
+      {
+        type: 'reference',
+        ref: 'Footer'
+      }
+    ]
+  }
+});
+
+// Generate imports for all referenced components
+const componentRefs = ['Header', 'Footer'];
+const imports = registry.generateImports(componentRefs);
+
+console.log(imports);
+```
+
+## Testing
+
+Run the registry tests:
+
+```bash
+node --test codegen/components/registry.test.js
+```
+
+## Default Component Mappings
+
+The registry comes with pre-configured mappings for common components:
+
+| .pen Name | React Component Path |
+|-----------|---------------------|
+| Header | ../components/Header |
+| Footer | ../components/Footer |
+| Hero | ../components/Hero |
+| Features | ../components/Features |
+| Stats | ../components/Stats |
+| Weather | ../components/Weather |
+| ArrivalCard | ../components/ArrivalCard |
+| HeatMapCard | ../components/HeatMapCard |
+| LivestreamCard | ../components/LivestreamCard |
+| TimeWeatherCard | ../components/TimeWeatherCard |
+| TopZonesCard | ../components/TopZonesCard |
+| TrafficCard | ../components/TrafficCard |
+| VisitStatsCard | ../components/VisitStatsCard |
+| Button | ../components/Button |
+
+## Acceptance Criteria
+
+- ✅ Header/Footer correctly mapped and referenced
+- ✅ Component parameters properly extracted
+- ✅ Import statements correctly generated
+- ✅ JSX references properly formatted
+- ✅ Custom component registration supported
+- ✅ Configuration file for persistent mappings
+
+## Related
+
+- [Template System](../README.md#template-system) - Reusable page layouts and components
+- [Code Generator](../README.md#generator-modules) - Convert .pen files to React components

--- a/codegen/components/components.config.json
+++ b/codegen/components/components.config.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "description": "Component mappings for Pencil Code Generator - Maps .pen component names to React component paths",
+  "components": {
+    "Header": "../components/Header",
+    "Footer": "../components/Footer",
+    "Hero": "../components/Hero",
+    "Features": "../components/Features",
+    "Stats": "../components/Stats",
+    "Weather": "../components/Weather",
+    "ArrivalCard": "../components/ArrivalCard",
+    "HeatMapCard": "../components/HeatMapCard",
+    "LivestreamCard": "../components/LivestreamCard",
+    "TimeWeatherCard": "../components/TimeWeatherCard",
+    "TopZonesCard": "../components/TopZonesCard",
+    "TrafficCard": "../components/TrafficCard",
+    "VisitStatsCard": "../components/VisitStatsCard",
+    "Button": "../components/Button"
+  }
+}

--- a/codegen/components/registry.js
+++ b/codegen/components/registry.js
@@ -1,0 +1,350 @@
+/**
+ * Component Registry for Pencil Code Generator
+ * Maps .pen component names to React component paths
+ * Handles parameter extraction and JSX reference generation
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join, dirname, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Default component mappings
+ * Maps .pen component names to React component relative paths
+ */
+const DEFAULT_COMPONENT_MAP = {
+  Header: '../components/Header',
+  Footer: '../components/Footer',
+  Hero: '../components/Hero',
+  Features: '../components/Features',
+  Stats: '../components/Stats',
+  Weather: '../components/Weather',
+  ArrivalCard: '../components/ArrivalCard',
+  HeatMapCard: '../components/HeatMapCard',
+  LivestreamCard: '../components/LivestreamCard',
+  TimeWeatherCard: '../components/TimeWeatherCard',
+  TopZonesCard: '../components/TopZonesCard',
+  TrafficCard: '../components/TrafficCard',
+  VisitStatsCard: '../components/VisitStatsCard',
+};
+
+/**
+ * Registry configuration
+ */
+class ComponentRegistry {
+  constructor(options = {}) {
+    this.componentMap = { ...DEFAULT_COMPONENT_MAP };
+    this.configPath = options.configPath || join(__dirname, 'components.config.json');
+    this.outputDir = options.outputDir || join(__dirname, '../../src/components');
+    
+    // Load custom mappings from config file
+    this.loadConfig();
+  }
+
+  /**
+   * Load component mappings from config file
+   */
+  loadConfig() {
+    if (existsSync(this.configPath)) {
+      try {
+        const config = JSON.parse(readFileSync(this.configPath, 'utf8'));
+        if (config.components) {
+          this.componentMap = { ...this.componentMap, ...config.components };
+        }
+      } catch (error) {
+        console.warn(`Failed to load component config: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Save component mappings to config file
+   */
+  saveConfig() {
+    const config = {
+      version: '1.0.0',
+      description: 'Component mappings for Pencil Code Generator',
+      components: this.componentMap,
+    };
+    
+    writeFileSync(this.configPath, JSON.stringify(config, null, 2), 'utf8');
+    console.log(`Component config saved to ${this.configPath}`);
+  }
+
+  /**
+   * Register a new component mapping
+   * @param {string} penName - .pen component name
+   * @param {string} reactPath - React component relative path
+   */
+  register(penName, reactPath) {
+    this.componentMap[penName] = reactPath;
+    return this;
+  }
+
+  /**
+   * Unregister a component mapping
+   * @param {string} penName - .pen component name
+   */
+  unregister(penName) {
+    delete this.componentMap[penName];
+    return this;
+  }
+
+  /**
+   * Check if a component is registered
+   * @param {string} penName - .pen component name
+   * @returns {boolean} True if registered
+   */
+  has(penName) {
+    return penName in this.componentMap;
+  }
+
+  /**
+   * Get the React component path for a .pen component name
+   * @param {string} penName - .pen component name
+   * @returns {string|null} React component path or null if not found
+   */
+  resolve(penName) {
+    return this.componentMap[penName] || null;
+  }
+
+  /**
+   * Get all registered components
+   * @returns {Object} Component mappings
+   */
+  getAll() {
+    return { ...this.componentMap };
+  }
+
+  /**
+   * Extract component parameters from a .pen frame definition
+   * @param {Object} frameData - .pen frame data
+   * @returns {Object} Extracted parameters
+   */
+  extractParams(frameData) {
+    if (!frameData || typeof frameData !== 'object') {
+      return {};
+    }
+
+    const params = {};
+
+    // Extract name
+    if (frameData.name) {
+      params.name = frameData.name;
+    }
+
+    // Extract dimensions
+    if (frameData.width !== undefined) {
+      params.width = frameData.width;
+    }
+    if (frameData.height !== undefined) {
+      params.height = frameData.height;
+    }
+
+    // Extract style properties
+    if (frameData.fill) {
+      params.fill = frameData.fill;
+    }
+    if (frameData.stroke) {
+      params.stroke = frameData.stroke;
+    }
+    if (frameData.cornerRadius) {
+      params.cornerRadius = frameData.cornerRadius;
+    }
+    if (frameData.padding) {
+      params.padding = frameData.padding;
+    }
+    if (frameData.gap) {
+      params.gap = frameData.gap;
+    }
+
+    // Extract layout properties
+    if (frameData.layout) {
+      params.layout = frameData.layout;
+    }
+    if (frameData.justifyContent) {
+      params.justifyContent = frameData.justifyContent;
+    }
+    if (frameData.alignItems) {
+      params.alignItems = frameData.alignItems;
+    }
+
+    // Extract text content for text elements
+    if (frameData.type === 'text' && frameData.content) {
+      params.content = frameData.content;
+    }
+    if (frameData.fontSize) {
+      params.fontSize = frameData.fontSize;
+    }
+    if (frameData.fontWeight) {
+      params.fontWeight = frameData.fontWeight;
+    }
+    if (frameData.fontFamily) {
+      params.fontFamily = frameData.fontFamily;
+    }
+
+    // Recursively extract params from children
+    if (frameData.children && Array.isArray(frameData.children)) {
+      params.children = frameData.children.map(child => this.extractParams(child));
+    }
+
+    return params;
+  }
+
+  /**
+   * Generate import statement for a component
+   * @param {string} penName - .pen component name
+   * @returns {string|null} Import statement or null if not found
+   */
+  generateImport(penName) {
+    const reactPath = this.resolve(penName);
+    if (!reactPath) {
+      return null;
+    }
+
+    // Convert path to import-friendly format
+    // e.g., "../components/Header" -> Header
+    const componentName = this.getComponentName(penName);
+    const importPath = reactPath.replace(/^\.\.?\//, './');
+    
+    return `import { ${componentName} } from '${importPath}';`;
+  }
+
+  /**
+   * Generate JSX reference for a component
+   * @param {string} penName - .pen component name
+   * @param {Object} props - Component props
+   * @returns {string|null} JSX string or null if not found
+   */
+  generateJSX(penName, props = {}) {
+    const reactPath = this.resolve(penName);
+    if (!reactPath) {
+      return null;
+    }
+
+    const componentName = this.getComponentName(penName);
+    
+    // Generate props string
+    const propsString = Object.entries(props)
+      .map(([key, value]) => {
+        if (typeof value === 'string') {
+          return `${key}="${value}"`;
+        }
+        if (typeof value === 'object') {
+          return `${key}={${JSON.stringify(value)}}`;
+        }
+        return `${key}={${value}}`;
+      })
+      .join(' ');
+
+    return propsString ? `<${componentName} ${propsString} />` : `<${componentName} />`;
+  }
+
+  /**
+   * Generate all imports for a set of components
+   * @param {Array<string>} penNames - List of .pen component names
+   * @returns {string} Combined import statements
+   */
+  generateImports(penNames) {
+    const imports = new Set();
+    
+    penNames.forEach(penName => {
+      const importStmt = this.generateImport(penName);
+      if (importStmt) {
+        imports.add(importStmt);
+      }
+    });
+
+    return Array.from(imports).join('\n');
+  }
+
+  /**
+   * Generate JSX for multiple components
+   * @param {Array<Object>} components - Array of { penName, props } objects
+   * @returns {string} Combined JSX string
+   */
+  generateJSXMultiple(components) {
+    return components
+      .map(({ penName, props = {} }) => this.generateJSX(penName, props))
+      .filter(Boolean)
+      .join('\n          ');
+  }
+
+  /**
+   * Get component name from pen name (PascalCase)
+   * @param {string} penName - .pen component name
+   * @returns {string} PascalCase component name
+   */
+  getComponentName(penName) {
+    // Convert to PascalCase if needed
+    return penName
+      .split(/[-_\s]+/)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join('');
+  }
+
+  /**
+   * Get the relative path from a source file to a component
+   * @param {string} sourceFile - Source file path
+   * @param {string} penName - .pen component name
+   * @returns {string|null} Relative import path or null
+   */
+  getRelativePath(sourceFile, penName) {
+    const reactPath = this.resolve(penName);
+    if (!reactPath) {
+      return null;
+    }
+
+    const sourceDir = dirname(sourceFile);
+    const componentPath = join(__dirname, reactPath);
+    return relative(sourceDir, componentPath).replace(/\\/g, '/');
+  }
+
+  /**
+   * Generate a complete React component with imported references
+   * @param {string} componentName - Name for the generated component
+   * @param {Array<Object>} children - Array of { penName, props } for child components
+   * @returns {string} Complete React component code
+   */
+  generateComponentWithRefs(componentName, children = []) {
+    const penNames = children.map(c => c.penName);
+    const imports = this.generateImports(penNames);
+    const jsx = this.generateJSXMultiple(children);
+
+    return `import React from 'react';
+${imports}
+
+/**
+ * ${componentName}
+ * Auto-generated component with referenced components
+ */
+export function ${componentName}() {
+  return (
+    <>
+      ${jsx}
+    </>
+  );
+}
+
+export default ${componentName};
+`;
+  }
+}
+
+/**
+ * Create a new component registry instance
+ * @param {Object} options - Registry options
+ * @returns {ComponentRegistry} Registry instance
+ */
+export function createRegistry(options = {}) {
+  return new ComponentRegistry(options);
+}
+
+/**
+ * Get the default registry instance
+ */
+export const registry = new ComponentRegistry();
+
+export default ComponentRegistry;

--- a/codegen/components/registry.test.js
+++ b/codegen/components/registry.test.js
@@ -1,0 +1,153 @@
+/**
+ * Tests for Component Registry
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import ComponentRegistry, { createRegistry, registry } from './registry.js';
+
+describe('ComponentRegistry', () => {
+  it('should create a registry with default mappings', () => {
+    const reg = new ComponentRegistry();
+    assert.ok(reg.has('Header'));
+    assert.ok(reg.has('Footer'));
+    assert.strictEqual(reg.resolve('Header'), '../components/Header');
+  });
+
+  it('should register new components', () => {
+    const reg = new ComponentRegistry();
+    reg.register('CustomButton', '../components/CustomButton');
+    assert.ok(reg.has('CustomButton'));
+    assert.strictEqual(reg.resolve('CustomButton'), '../components/CustomButton');
+  });
+
+  it('should unregister components', () => {
+    const reg = new ComponentRegistry();
+    reg.unregister('Header');
+    assert.strictEqual(reg.has('Header'), false);
+  });
+
+  it('should extract parameters from frame data', () => {
+    const reg = new ComponentRegistry();
+    const frameData = {
+      type: 'frame',
+      name: 'TestFrame',
+      width: 1440,
+      height: 600,
+      fill: '#ffffff',
+      padding: [20, 40],
+      layout: 'vertical',
+      children: [
+        {
+          type: 'text',
+          content: 'Hello',
+          fontSize: 24,
+          fontWeight: 'bold',
+        },
+      ],
+    };
+
+    const params = reg.extractParams(frameData);
+    assert.strictEqual(params.name, 'TestFrame');
+    assert.strictEqual(params.width, 1440);
+    assert.strictEqual(params.height, 600);
+    assert.strictEqual(params.fill, '#ffffff');
+    assert.deepStrictEqual(params.padding, [20, 40]);
+    assert.strictEqual(params.layout, 'vertical');
+    assert.ok(Array.isArray(params.children));
+    assert.strictEqual(params.children[0].content, 'Hello');
+    assert.strictEqual(params.children[0].fontSize, 24);
+  });
+
+  it('should generate import statements', () => {
+    const reg = new ComponentRegistry();
+    const importStmt = reg.generateImport('Header');
+    assert.strictEqual(importStmt, "import { Header } from './components/Header';");
+  });
+
+  it('should generate JSX references', () => {
+    const reg = new ComponentRegistry();
+    const jsx = reg.generateJSX('Header', { logoText: 'MyBrand' });
+    assert.strictEqual(jsx, '<Header logoText="MyBrand" />');
+  });
+
+  it('should generate JSX without props', () => {
+    const reg = new ComponentRegistry();
+    const jsx = reg.generateJSX('Header');
+    assert.strictEqual(jsx, '<Header />');
+  });
+
+  it('should generate multiple imports', () => {
+    const reg = new ComponentRegistry();
+    const imports = reg.generateImports(['Header', 'Footer']);
+    assert.ok(imports.includes("import { Header } from './components/Header';"));
+    assert.ok(imports.includes("import { Footer } from './components/Footer';"));
+  });
+
+  it('should generate JSX for multiple components', () => {
+    const reg = new ComponentRegistry();
+    const jsx = reg.generateJSXMultiple([
+      { penName: 'Header', props: { logoText: 'Brand' } },
+      { penName: 'Footer' },
+    ]);
+    assert.ok(jsx.includes('<Header logoText="Brand" />'));
+    assert.ok(jsx.includes('<Footer />'));
+  });
+
+  it('should convert names to PascalCase', () => {
+    const reg = new ComponentRegistry();
+    assert.strictEqual(reg.getComponentName('header'), 'Header');
+    assert.strictEqual(reg.getComponentName('my-component'), 'MyComponent');
+    assert.strictEqual(reg.getComponentName('test_frame'), 'TestFrame');
+  });
+
+  it('should generate component with references', () => {
+    const reg = new ComponentRegistry();
+    const code = reg.generateComponentWithRefs('TestPage', [
+      { penName: 'Header', props: { logoText: 'Test' } },
+      { penName: 'Footer' },
+    ]);
+
+    assert.ok(code.includes("import { Header } from './components/Header';"));
+    assert.ok(code.includes("import { Footer } from './components/Footer';"));
+    assert.ok(code.includes('<Header logoText="Test" />'));
+    assert.ok(code.includes('<Footer />'));
+    assert.ok(code.includes('export function TestPage()'));
+  });
+
+  it('should return null for unregistered components', () => {
+    const reg = new ComponentRegistry();
+    assert.strictEqual(reg.resolve('NonExistent'), null);
+    assert.strictEqual(reg.generateImport('NonExistent'), null);
+    assert.strictEqual(reg.generateJSX('NonExistent'), null);
+  });
+
+  it('should get all registered components', () => {
+    const reg = new ComponentRegistry();
+    const all = reg.getAll();
+    assert.ok(all.Header);
+    assert.ok(all.Footer);
+    assert.strictEqual(all.Header, '../components/Header');
+  });
+});
+
+describe('createRegistry', () => {
+  it('should create a new registry instance', () => {
+    const reg = createRegistry();
+    assert.ok(reg instanceof ComponentRegistry);
+  });
+
+  it('should accept custom options', () => {
+    const reg = createRegistry({ configPath: '/custom/path/config.json' });
+    assert.ok(reg instanceof ComponentRegistry);
+  });
+});
+
+describe('default registry', () => {
+  it('should export a default registry instance', () => {
+    assert.ok(registry);
+    assert.ok(registry.has('Header'));
+  });
+});
+
+console.log('All registry tests passed! ✅');


### PR DESCRIPTION
## Summary

Implements a component registry system that maps .pen design component names to React component paths. This enables automatic code generation with proper imports and JSX references for reusable components like Header and Footer.

## Changes

- Added `codegen/components/registry.js` - Core registry with parameter extraction and JSX generation
- Added `codegen/components/components.config.json` - Persistent component mapping configuration
- Added `codegen/components/registry.test.js` - Comprehensive test suite (16 tests, all passing)
- Added `codegen/components/README.md` - Complete usage documentation with examples
- Updated `codegen/README.md` with component registry documentation and API reference

## Features

- **Component Mapping**: Maps .pen names (Header, Footer) to React component paths
- **Parameter Extraction**: Extracts props from .pen frame definitions
- **Import Generation**: Automatically generates import statements
- **JSX Generation**: Creates properly formatted JSX with props
- **Custom Registration**: Supports registering new components dynamically
- **Configuration**: JSON config file for persistent mappings

## Testing

All 16 registry tests pass:
```bash
node --test codegen/components/registry.test.js
```

## Integration

Works with the template system from issue #8 to provide complete component composition:
- Templates define structure
- Registry provides component resolution and import generation

Fixes PKUbuntu/pencil-homepage#9